### PR TITLE
Seperate device info of NVR and connected cameras

### DIFF
--- a/custom_components/reolink_cctv/entity.py
+++ b/custom_components/reolink_cctv/entity.py
@@ -17,12 +17,24 @@ class ReolinkCoordinatorEntity(CoordinatorEntity):
         self._host: ReolinkHost = hass.data[DOMAIN][config.entry_id][HOST]
         self._hass              = hass
         self._state             = False
+        self._channel           = None
     #endof __init__()
 
 
     @property
     def device_info(self):
         """Information about this entity/device."""
+        conf_url = f"https://{self._host.api._host}:{self._host.api._port}" if self._host.api._use_https else f"http://{self._host.api._host}:{self._host.api._port}"
+        if self._host.api.is_nvr and self._channel is not None:
+            return {
+                "identifiers":          {(DOMAIN, f"{self._host.unique_id}_ch{self._channel}")},
+                "via_device":           (DOMAIN, self._host.unique_id)
+                "name":                 self._host.api.camera_name(self._channel),
+                "model":                self._host.api.camera_model(self._channel),
+                "manufacturer":         self._host.api.manufacturer,
+                "configuration_url":    conf_url
+            }
+
         return {
             "identifiers":          {(DOMAIN, self._host.unique_id)},
             "connections":          {(CONNECTION_NETWORK_MAC, self._host.api.mac_address)},
@@ -31,7 +43,7 @@ class ReolinkCoordinatorEntity(CoordinatorEntity):
             "hw_version":           self._host.api.hardware_version,
             "model":                self._host.api.model,
             "manufacturer":         self._host.api.manufacturer,
-            "configuration_url":    f"https://{self._host.api._host}:{self._host.api._port}" if self._host.api._use_https else f"http://{self._host.api._host}:{self._host.api._port}"
+            "configuration_url":    conf_url
         }
     #endof device_info
 

--- a/custom_components/reolink_cctv/entity.py
+++ b/custom_components/reolink_cctv/entity.py
@@ -28,11 +28,11 @@ class ReolinkCoordinatorEntity(CoordinatorEntity):
         if self._host.api.is_nvr and self._channel is not None:
             return {
                 "identifiers":          {(DOMAIN, f"{self._host.unique_id}_ch{self._channel}")},
-                "via_device":           (DOMAIN, self._host.unique_id)
+                "via_device":           (DOMAIN, self._host.unique_id),
                 "name":                 self._host.api.camera_name(self._channel),
                 "model":                self._host.api.camera_model(self._channel),
                 "manufacturer":         self._host.api.manufacturer,
-                "configuration_url":    conf_url
+                "configuration_url":    conf_url,
             }
 
         return {
@@ -43,7 +43,7 @@ class ReolinkCoordinatorEntity(CoordinatorEntity):
             "hw_version":           self._host.api.hardware_version,
             "model":                self._host.api.model,
             "manufacturer":         self._host.api.manufacturer,
-            "configuration_url":    conf_url
+            "configuration_url":    conf_url,
         }
     #endof device_info
 

--- a/custom_components/reolink_cctv/entity.py
+++ b/custom_components/reolink_cctv/entity.py
@@ -28,9 +28,9 @@ class ReolinkCoordinatorEntity(CoordinatorEntity):
             "connections":          {(CONNECTION_NETWORK_MAC, self._host.api.mac_address)},
             "name":                 self._host.api.nvr_name,
             "sw_version":           self._host.api.sw_version,
+            "hw_version":           self._host.api.hardware_version,
             "model":                self._host.api.model,
             "manufacturer":         self._host.api.manufacturer,
-            "channels":             self._host.api.num_channels,
             "configuration_url":    f"https://{self._host.api._host}:{self._host.api._port}" if self._host.api._use_https else f"http://{self._host.api._host}:{self._host.api._port}"
         }
     #endof device_info


### PR DESCRIPTION
Needs the upstream lib PR merged: https://github.com/JimStar/reolink_ip/pull/6

This is how it looks with this PR:
This will allow to quickly see which automations belong to which camera.
It also allows you to set the location/room of each camera and shows the model of each camera.
The camera's are 'connected_via' the NVR.

![Reolink_dev_info_1](https://user-images.githubusercontent.com/14811189/204397178-500d6fec-c059-4138-9596-bfb80e60da28.PNG)
![Reolink_dev_info_2](https://user-images.githubusercontent.com/14811189/204397180-db1ebf78-e5c9-41c2-b1e4-6faaaf13d463.PNG)
![Reolink_dev_info_3](https://user-images.githubusercontent.com/14811189/204397181-44b72ba5-516f-40ed-b399-f2de20ddb489.PNG)
