### PR TITLE
Auto enable RTMP and RTSP ports

### DIFF
--- a/custom_components/reolink_cctv/host.py
+++ b/custom_components/reolink_cctv/host.py
@@ -174,10 +174,10 @@ class ReolinkHost:
             if self._api.mac_address is None:
                 return False
 
-            if not self._api.onvif_enabled:
-                _LOGGER.info("ONVIF is disabled on %s, trying to enable it...", self._api.nvr_name)
-                if not await self._api.set_net_port(True):
-                    _LOGGER.error("Unable to switch on ONVIF on %s. You need it to be ON to receive notifications.", self._api.nvr_name)
+            if not self._api.onvif_enabled or not self._api.rtmp_enabled or not self._api.rtsp_enabled:
+                _LOGGER.info("ONVIF, RTMP or RTSP is disabled on %s, trying to enable it...", self._api.nvr_name)
+                if not await self._api.set_net_port(enable_onvif = True, enable_rtmp = True, enable_rtsp = True):
+                    _LOGGER.error("Unable to switch on ONVIF, RTMP and RTSP on %s. You need it to be ON to receive notifications and view camera streams.", self._api.nvr_name)
 
             self.motion_detection_enabled = {c: True for c in self._api.channels}
 


### PR DESCRIPTION
Needs https://github.com/JimStar/reolink_ip/pull/7 to be merged first.

These ports are needed in HomeAssistant for streaming, so we schould auto-enable them when needed.
By default these ports are closed on the NVR/camera.