### PR TITLE
Remove stream format option

### DIFF
--- a/custom_components/reolink_cctv/__init__.py
+++ b/custom_components/reolink_cctv/__init__.py
@@ -27,7 +27,6 @@ from .const import (
     CONF_PROTOCOL,
     CONF_STREAM,
     CONF_THUMBNAIL_PATH,
-    CONF_STREAM_FORMAT,
     CONF_SUBSCRIPTION_WATCHDOG_INTERVAL,
     DEFAULT_EXTERNAL_HOST,
     DEFAULT_EXTERNAL_PORT,
@@ -36,7 +35,6 @@ from .const import (
     DEFAULT_MOTION_OFF_DELAY,
     DEFAULT_PLAYBACK_DAYS,
     DEFAULT_STREAM,
-    DEFAULT_STREAM_FORMAT,
     DEFAULT_SUBSCRIPTION_WATCHDOG_INTERVAL,
     DEFAULT_TIMEOUT,
     DEVICE_CONFIG_UPDATE_COORDINATOR,
@@ -166,7 +164,6 @@ async def entry_update_listener(hass: HomeAssistant, entry: ConfigEntry):
     host.api.timeout        = entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
     host.api.protocol       = entry.options.get(CONF_PROTOCOL, DEFAULT_PROTOCOL)
     host.api.stream         = entry.options.get(CONF_STREAM, DEFAULT_STREAM)
-    host.api.stream_format  = entry.options.get(CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT)
 
     coordinator_subscription_watchdog: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][SUBSCRIPTION_WATCHDOG_COORDINATOR]
 

--- a/custom_components/reolink_cctv/config_flow.py
+++ b/custom_components/reolink_cctv/config_flow.py
@@ -26,7 +26,6 @@ from .const import (
     CONF_PLAYBACK_DAYS,
     CONF_PROTOCOL,
     CONF_STREAM,
-    CONF_STREAM_FORMAT,
     CONF_THUMBNAIL_PATH,
     CONF_SUBSCRIPTION_WATCHDOG_INTERVAL,
     DEFAULT_EXTERNAL_HOST,
@@ -37,7 +36,6 @@ from .const import (
     DEFAULT_PLAYBACK_DAYS,
     DEFAULT_PROTOCOL,
     DEFAULT_STREAM,
-    DEFAULT_STREAM_FORMAT,
     DEFAULT_TIMEOUT,
     DEFAULT_SUBSCRIPTION_WATCHDOG_INTERVAL,
     DOMAIN
@@ -219,11 +217,6 @@ class ReolinkOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_STREAM,
                         default = self.config_entry.options.get(CONF_STREAM, DEFAULT_STREAM),
                     ): vol.In(["main", "sub", "ext"]),
-
-                    vol.Required(
-                        CONF_STREAM_FORMAT,
-                        default = self.config_entry.options.get(CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT),
-                    ): vol.In(["h264", "h265"]),
 
                     vol.Required(
                         CONF_MOTION_OFF_DELAY,

--- a/custom_components/reolink_cctv/const.py
+++ b/custom_components/reolink_cctv/const.py
@@ -17,7 +17,6 @@ CONF_EXTERNAL_HOST                      = "external_host"
 CONF_EXTERNAL_PORT                      = "external_port"
 CONF_USE_HTTPS                          = "use_https"
 CONF_STREAM                             = "stream"
-CONF_STREAM_FORMAT                      = "stream_format"
 CONF_PROTOCOL                           = "protocol"
 CONF_MOTION_OFF_DELAY                   = "motion_off_delay"
 CONF_MOTION_FORCE_OFF                   = "motion_force_off"
@@ -33,7 +32,6 @@ DEFAULT_MOTION_OFF_DELAY                = 5
 DEFAULT_MOTION_FORCE_OFF                = 0
 DEFAULT_PROTOCOL                        = "rtmp"
 DEFAULT_STREAM                          = "sub"
-DEFAULT_STREAM_FORMAT                   = "h264"
 DEFAULT_SUBSCRIPTION_WATCHDOG_INTERVAL  = 60
 
 DEFAULT_TIMEOUT                         = 60

--- a/custom_components/reolink_cctv/host.py
+++ b/custom_components/reolink_cctv/host.py
@@ -43,7 +43,6 @@ from .const import (
     CONF_MOTION_FORCE_OFF,
     CONF_PROTOCOL,
     CONF_STREAM,
-    CONF_STREAM_FORMAT,
     CONF_SUBSCRIPTION_WATCHDOG_INTERVAL,
     DEFAULT_USE_HTTPS,
     DEFAULT_CHANNELS,
@@ -51,7 +50,6 @@ from .const import (
     DEFAULT_MOTION_FORCE_OFF,
     DEFAULT_PROTOCOL,
     DEFAULT_STREAM,
-    DEFAULT_STREAM_FORMAT,
     DEFAULT_TIMEOUT,
     DEFAULT_SUBSCRIPTION_WATCHDOG_INTERVAL,
     DOMAIN,
@@ -113,7 +111,6 @@ class ReolinkHost:
             config[CONF_PASSWORD],
             use_https = use_https,
             stream = (DEFAULT_STREAM if CONF_STREAM not in options else options[CONF_STREAM]),
-            stream_format = (DEFAULT_STREAM_FORMAT if CONF_STREAM_FORMAT not in options else options[CONF_STREAM_FORMAT]),
             protocol = (DEFAULT_PROTOCOL if CONF_PROTOCOL not in options else options[CONF_PROTOCOL]),
             timeout = (DEFAULT_TIMEOUT if CONF_TIMEOUT not in options else options[CONF_TIMEOUT]),
             aiohttp_get_session_callback = self.get_iohttp_session

--- a/custom_components/reolink_cctv/strings.json
+++ b/custom_components/reolink_cctv/strings.json
@@ -38,8 +38,7 @@
           "motion_off_delay": "Motion sensor off delay (seconds)",
           "motion_force_off": "Motion sensor force-off timeout (seconds)",
           "playback_days": "Playback range (days)",
-          "playback_thumbnail_path": "Custom thumbnail path",
-          "stream_format": "Stream format"
+          "playback_thumbnail_path": "Custom thumbnail path"
         }
       }
     }


### PR DESCRIPTION
Remove the stream_format option, since this only causes issue.
A stream is only available in one stream_format anyway (most cases h264).

It was only used for RTSP streams and even there it is not needed and actually not recommanded in the latest API manual of reolink:

> The following is the rtsp url of the historical version, no longer
> recommended, but still compatible.

Specifying a incompatible stream_format would result in the stream not loading, so we are only making our lives difficult with this option.